### PR TITLE
Remove useless getcwd.

### DIFF
--- a/src/Json/JsonContext.php
+++ b/src/Json/JsonContext.php
@@ -142,7 +142,7 @@ class JsonContext extends BehatContext implements JsonStorageAware
             $this->readJson(),
             new JsonSchema(
                 file_get_contents($filename),
-                'file://' . getcwd() . '/' . $filename
+                'file://' . $filename
             )
         );
     }


### PR DESCRIPTION
As we use realpath to resolve the filename, we don't need to prefix filename.