### PR TITLE
Expose RestApiContext::request and RestApiContext::response

### DIFF
--- a/tests/Units/RestApiContext.php
+++ b/tests/Units/RestApiContext.php
@@ -6,23 +6,20 @@ use atoum;
 use Rezzza\JsonApiBehatExtension\RestApiContext as SUT;
 
 /**
- * Description of RestApiContext
- *
  * @author Mikaël FIMA <mika@verylastroom.com>
+ * @author Guillaume MOREL <guillaume.morel@verylastroom.com>
  */
 class RestApiContext extends atoum
 {
-
     /**
      * Adding headers
      * @dataProvider addHeaderDataProvider
      */
-    public function testAddHeader(array $addHeadersSteps, array $expectedHeaders)
+    public function testAddRequestHeader(array $addHeadersSteps, array $expectedHeaders)
     {
         $this
             ->given(
-                $httpClient = new \mock\Guzzle\Http\Client(),
-                $httpClient->getMockController()->send = new \Guzzle\Http\Message\Response(200)
+                $httpClient = $this->mockHttpClient(200)
             )
             ->and($sut = new SUT($httpClient, null, false))
         ;
@@ -34,7 +31,7 @@ class RestApiContext extends atoum
         }
 
         $this
-            ->array($sut->getHeaders())->isIdenticalTo($expectedHeaders)
+            ->array($sut->getRequestHeaders())->isIdenticalTo($expectedHeaders)
         ;
     }
 
@@ -51,12 +48,11 @@ class RestApiContext extends atoum
      * Setting headers
      * @dataProvider setHeaderDataProvider
      */
-    public function testSetHeader(array $setHeadersSteps, array $expectedHeaders)
+    public function testSetRequestHeader(array $setHeadersSteps, array $expectedHeaders)
     {
         $this
             ->given(
-                $httpClient = new \mock\Guzzle\Http\Client(),
-                $httpClient->getMockController()->send = new \Guzzle\Http\Message\Response(200)
+                $httpClient = $this->mockHttpClient(200)
             )
             ->and($sut = new SUT($httpClient, null, false))
         ;
@@ -68,7 +64,7 @@ class RestApiContext extends atoum
         }
 
         $this
-            ->array($sut->getHeaders())->isIdenticalTo($expectedHeaders)
+            ->array($sut->getRequestHeaders())->isIdenticalTo($expectedHeaders)
         ;
     }
 
@@ -79,5 +75,102 @@ class RestApiContext extends atoum
             array(array(array("name" => "value")), array("name" => "value")),
             array(array(array("name" => "value"), array("name" => "value2")), array("name" => "value2")),
         );
+    }
+
+    /**
+     * @dataProvider requestDataProvider
+     * @param array $requestHeaders
+     */
+    public function test_get_request(array $requestHeaders)
+    {
+        // Given
+        $mockHttpClient = $this->mockHttpClient(200, array());
+
+        $restApiContext = new SUT($mockHttpClient, null, false);
+        foreach ($requestHeaders as $requestHeaderKey => $requestHeaderValue) {
+            $restApiContext->iAddHeaderEqualTo($requestHeaderKey, $requestHeaderValue);
+        }
+
+        // When
+        $restApiContext->iSendARequest('GET', 'http://verylastroom.com/');
+
+        // Then
+        $request = $restApiContext->getRequest();
+        $intersect = array_intersect_key($requestHeaders, $request->getHeaders()->toArray());
+
+        $this->array($requestHeaders)->isEqualTo($intersect);
+    }
+
+    public function requestDataProvider()
+    {
+        return array(
+            array(
+                'requestHeaders' => array(
+                    array("name" => "value")
+                )
+            ),
+            array(
+                'requestHeaders' => array(
+                    array("name1" => "value1"), array("name2" => "value2")
+                )
+            )
+        );
+    }
+
+    /**
+     * @dataProvider responseDataProvider
+     * @param int   $statusCode
+     * @param array $responseHeaders
+     */
+    public function test_get_response($statusCode, array $responseHeaders)
+    {
+        // Given
+        $mockHttpClient = $this->mockHttpClient($statusCode, $responseHeaders);
+
+        $restApiContext = new SUT($mockHttpClient, null, false);
+
+        // When
+        $restApiContext->iSendARequest('GET', 'http://verylastroom.com/');
+
+        // Then
+        $response = $restApiContext->getResponse();
+        $intersect = array_intersect_key($responseHeaders, $response->getHeaders()->toArray());
+
+        $this->array($responseHeaders)->isEqualTo($intersect);
+    }
+
+    public function responseDataProvider()
+    {
+        return array(
+            array(
+                'statusCode' => 200,
+                'requestHeaders' => array(
+                    array("name" => "value")
+                )
+            ),
+            array(
+                'statusCode' => 400,
+                'requestHeaders' => array(
+                    array("name1" => "value1"), array("name2" => "value2")
+                )
+            )
+        );
+    }
+
+    /**
+     * @param int   $responseStatusCode
+     * @param array $headers
+     *
+     * @return \Guzzle\Http\Client
+     */
+    private function mockHttpClient($responseStatusCode, array $headers = array())
+    {
+        $mockHttpClient = new \mock\Guzzle\Http\Client();
+        $mockHttpClient->getMockController()->send = new \Guzzle\Http\Message\Response(
+            $responseStatusCode,
+            $headers
+        );
+
+        return $mockHttpClient;
     }
 }


### PR DESCRIPTION
In order to allow deep testing from other contexts
Rename RestApiContext::headers into RestApiContext::requestHeaders

BC keep RestApiContext::getHeaders() as alias but deprecated